### PR TITLE
Fix $c->req->url->to_abs

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,0 +1,12 @@
+-pbp     # Start with Perl Best Practices
+-w       # Show all warnings
+-iob     # Ignore old breakpoints
+-l=80    # 80 characters per line
+-mbl=2   # No more than 2 blank lines
+-i=2     # Indentation is 2 columns
+-ci=2    # Continuation indentation is 2 columns
+-vt=0    # Less vertical tightness
+-pt=2    # High parenthesis tightness
+-bt=2    # High brace tightness
+-sbt=2   # High square bracket tightness
+-isbc    # Don't indent comments without leading space

--- a/lib/Mojolicious/Plugin/RequestBase.pm
+++ b/lib/Mojolicious/Plugin/RequestBase.pm
@@ -9,6 +9,8 @@ sub register {
     before_dispatch => sub {
       my $c = shift;
       if (my $base = $c->req->headers->header('X-Request-Base')) {
+        $base = "$base/" unless $base =~ m!/$!;
+        $c->req->url->path->leading_slash(0);
         $c->req->url->base(Mojo::URL->new($base));
       }
     }

--- a/lib/Mojolicious/Plugin/RequestBase.pm
+++ b/lib/Mojolicious/Plugin/RequestBase.pm
@@ -5,12 +5,14 @@ our $VERSION = '0.1';
 
 sub register {
   my ($self, $app) = @_;
-  $app->hook(before_dispatch => sub {
-    my $this=shift;
-    if(my $base=$this->req->headers->header('X-Request-Base')) {
-      $this->req->url->base(Mojo::URL->new($base));
+  $app->hook(
+    before_dispatch => sub {
+      my $c = shift;
+      if (my $base = $c->req->headers->header('X-Request-Base')) {
+        $c->req->url->base(Mojo::URL->new($base));
+      }
     }
-  });
+  );
 }
 
 1;

--- a/t/basic.t
+++ b/t/basic.t
@@ -9,7 +9,7 @@ plugin 'RequestBase';
 
 get '/' => sub {
   my $c = shift;
-  $c->render(text=>$c->url_for('login'));
+  $c->render(text => $c->url_for('login'));
 };
 
 get '/login', 'login';
@@ -17,6 +17,7 @@ get '/login', 'login';
 my $t = Test::Mojo->new;
 $t->get_ok('/')->status_is(200)->content_is('/login');
 
-$t->get_ok('/', {'X-Request-Base' => 'http://example.com/foo'})->status_is(200)->content_is('/foo/login');
+$t->get_ok('/', {'X-Request-Base' => 'http://example.com/foo'})->status_is(200)
+  ->content_is('/foo/login');
 
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -12,6 +12,12 @@ get '/' => sub {
   $c->render(text => $c->url_for('login'));
 };
 
+get '/redirect' => sub {
+  my $c   = shift;
+  my $url = $c->req->url->to_abs;
+  $c->redirect_to("http://example.com?from=$url");
+};
+
 get '/login', 'login';
 
 my $t = Test::Mojo->new;
@@ -19,5 +25,10 @@ $t->get_ok('/')->status_is(200)->content_is('/login');
 
 $t->get_ok('/', {'X-Request-Base' => 'http://example.com/foo'})->status_is(200)
   ->content_is('/foo/login');
+
+$t->get_ok('/redirect', {'X-Request-Base' => 'http://mojolicio.us/foo'})
+  ->status_is(302)
+  ->header_is(
+  Location => 'http://example.com?from=http://mojolicio.us/foo/redirect');
 
 done_testing;


### PR DESCRIPTION
This pull request fix making an absolute URL. Before this, the "Location" header would be set to "http://example.com?from=http://mojolicio.us/redirect".

Let's discuss this in #mojo, unless you think the fix makes sense @marcusramberg.

I think it's a bit weird that ```Mojo::URL->to_abs``` checks for the leading_slash().